### PR TITLE
Verification step added

### DIFF
--- a/tests/Test-ExeConflictCheck.ps1
+++ b/tests/Test-ExeConflictCheck.ps1
@@ -240,6 +240,12 @@ try {
     Assert "EC-11: Remove-AppxPackage mentioned"           ($out11 -match "Remove-AppxPackage")
     Assert "EC-11: no elevation required for Store uninstall" ($out11 -match "no elevation required")
 
+    # [EC-12] Toolset dir check is case-insensitive: toolsetdir in UPPERCASE must still skip its own shims
+    Write-Host "[EC-12] Toolset dir check is case-insensitive"
+    $out12 = Invoke-ConflictCheckTest -ToolsetDir $fakeToolset.ToUpper() `
+        -TestPath $fakeShims -ExeName "node" -DisplayName "Node.js"
+    Assert "EC-12: no warning when toolsetdir casing differs" (-not ($out12 -match "WARNING_DETECTED"))
+
 } finally {
     if (Test-Path $fakeToolset)      { Remove-Item $fakeToolset      -Recurse -Force -ErrorAction SilentlyContinue }
     if (Test-Path $fakeAdmin)        { Remove-Item $fakeAdmin        -Recurse -Force -ErrorAction SilentlyContinue }

--- a/tests/Test-ExeConflictCheck.ps1
+++ b/tests/Test-ExeConflictCheck.ps1
@@ -77,7 +77,7 @@ function Invoke-ConflictCheckTest {
     $escExe          = $ExeName.Replace("'", "''")
     $escDisplay      = $DisplayName.Replace("'", "''")
     $escSearch       = $UninstallSearch.Replace("'", "''")
-    $escLocalAppData = $LocalAppData.Replace("'", "''")
+    $escLocalAppData = if ($LocalAppData) { $LocalAppData.Replace("'", "''") } else { '' }
 
     $fakeBody = if ($FakeUninstall -eq 'found') {
         "return [PSCustomObject]@{ DisplayName = 'FakeApp 1.0'; QuietUninstallString = 'MsiExec.exe /X{FAKE-GUID}' }"

--- a/tests/Test-ExeConflictCheck.ps1
+++ b/tests/Test-ExeConflictCheck.ps1
@@ -142,12 +142,14 @@ $uid              = [guid]::NewGuid().ToString('N').Substring(0, 8)
 $fakeToolset      = Join-Path $tmp "ec-toolset-$uid"
 $fakeAdmin        = Join-Path $tmp "ec-admin-$uid"
 $fakeShims        = Join-Path $fakeToolset "shims"
+$fakeSibling      = $fakeToolset + "-sibling"   # shares the toolset prefix but is NOT inside it
 $fakeLocalAppData = Join-Path $tmp "ec-localappdata-$uid"
 $fakeWindowsApps  = Join-Path $fakeLocalAppData "Microsoft\WindowsApps"
 
 try {
     New-Item -Force -ItemType Directory $fakeShims       | Out-Null
     New-Item -Force -ItemType Directory $fakeAdmin       | Out-Null
+    New-Item -Force -ItemType Directory $fakeSibling     | Out-Null
     New-Item -Force -ItemType Directory $fakeWindowsApps | Out-Null
     Set-Content (Join-Path $fakeShims "node.cmd")         "@echo off" -Encoding ASCII
     Set-Content (Join-Path $fakeShims "python.cmd")       "@echo off" -Encoding ASCII
@@ -155,6 +157,7 @@ try {
     Set-Content (Join-Path $fakeAdmin "node.cmd")         "@echo off" -Encoding ASCII
     Set-Content (Join-Path $fakeAdmin "python.cmd")       "@echo off" -Encoding ASCII
     Set-Content (Join-Path $fakeAdmin "code.cmd")         "@echo off" -Encoding ASCII
+    Set-Content (Join-Path $fakeSibling "node.cmd")       "@echo off" -Encoding ASCII
     # Simulate Microsoft Store app execution aliases: cmd stubs in WindowsApps
     Set-Content (Join-Path $fakeWindowsApps "python.cmd") "@echo off" -Encoding ASCII
     Set-Content (Join-Path $fakeWindowsApps "wsl.cmd")    "@echo off" -Encoding ASCII
@@ -246,9 +249,17 @@ try {
         -TestPath $fakeShims -ExeName "node" -DisplayName "Node.js"
     Assert "EC-12: no warning when toolsetdir casing differs" (-not ($out12 -match "WARNING_DETECTED"))
 
+    # [EC-13] Toolset dir prefix collision: sibling dir sharing same prefix must still be flagged
+    Write-Host "[EC-13] Toolset dir prefix does not match sibling dir"
+    $out13 = Invoke-ConflictCheckTest -ToolsetDir $fakeToolset `
+        -TestPath "$fakeShims;$fakeSibling" -ExeName "node" -DisplayName "Node.js"
+    Assert "EC-13: warning emitted for sibling dir conflict" ($out13 -match "WARNING_DETECTED")
+    Assert "EC-13: warning references sibling path"          ($out13 -match [regex]::Escape($fakeSibling))
+
 } finally {
     if (Test-Path $fakeToolset)      { Remove-Item $fakeToolset      -Recurse -Force -ErrorAction SilentlyContinue }
     if (Test-Path $fakeAdmin)        { Remove-Item $fakeAdmin        -Recurse -Force -ErrorAction SilentlyContinue }
+    if (Test-Path $fakeSibling)      { Remove-Item $fakeSibling      -Recurse -Force -ErrorAction SilentlyContinue }
     if (Test-Path $fakeLocalAppData) { Remove-Item $fakeLocalAppData -Recurse -Force -ErrorAction SilentlyContinue }
 }
 

--- a/tests/Test-ExeConflictCheck.ps1
+++ b/tests/Test-ExeConflictCheck.ps1
@@ -57,25 +57,52 @@ function Invoke-ConflictCheckTest {
         # Controls what the fake Find-UninstallEntry returns.
         # 'none'   = returns $null (not found in registry)
         # 'found'  = returns an object with DisplayName + QuietUninstallString
-        [string]$FakeUninstall = 'none'
+        [string]$FakeUninstall = 'none',
+        # Override LOCALAPPDATA in the subprocess (used to simulate WindowsApps paths)
+        [string]$LocalAppData = $env:LOCALAPPDATA,
+        # If set, injects a fake Get-AppxPackage returning a package whose install dir
+        # contains this filename -- simulates a real Microsoft Store app installation.
+        [string]$FakeStoreExeName = ''
     )
 
-    $funcFile   = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), ".ps1")
-    $mainScript = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), ".ps1")
+    $funcFile        = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), ".ps1")
+    $mainScript      = [System.IO.Path]::ChangeExtension([System.IO.Path]::GetTempFileName(), ".ps1")
+    $fakeStorePkgDir = $null
 
     Set-Content $funcFile ($findUninstallSrc + "`n" + $conflictCheckSrc) -Encoding UTF8
 
-    $escToolset = $ToolsetDir.Replace("'", "''")
-    $escPath    = $TestPath.Replace("'", "''")
-    $escFunc    = $funcFile.Replace("'", "''")
-    $escExe     = $ExeName.Replace("'", "''")
-    $escDisplay = $DisplayName.Replace("'", "''")
-    $escSearch  = $UninstallSearch.Replace("'", "''")
+    $escToolset      = $ToolsetDir.Replace("'", "''")
+    $escPath         = $TestPath.Replace("'", "''")
+    $escFunc         = $funcFile.Replace("'", "''")
+    $escExe          = $ExeName.Replace("'", "''")
+    $escDisplay      = $DisplayName.Replace("'", "''")
+    $escSearch       = $UninstallSearch.Replace("'", "''")
+    $escLocalAppData = $LocalAppData.Replace("'", "''")
 
     $fakeBody = if ($FakeUninstall -eq 'found') {
         "return [PSCustomObject]@{ DisplayName = 'FakeApp 1.0'; QuietUninstallString = 'MsiExec.exe /X{FAKE-GUID}' }"
     } else {
         "return `$null"
+    }
+
+    # Build optional Get-AppxPackage override: function takes precedence over cmdlet in PS
+    $storeOverride = ''
+    if ($FakeStoreExeName) {
+        $uid2            = [guid]::NewGuid().ToString('N').Substring(0, 8)
+        $fakeStorePkgDir = Join-Path ([System.IO.Path]::GetTempPath()) "fake-store-$uid2"
+        New-Item -Force -ItemType Directory $fakeStorePkgDir | Out-Null
+        Set-Content (Join-Path $fakeStorePkgDir $FakeStoreExeName) "@echo off" -Encoding ASCII
+        $escPkgDir     = $fakeStorePkgDir.Replace("'", "''")
+        $storeOverride = @"
+function Get-AppxPackage {
+    [CmdletBinding()] param()
+    return @([PSCustomObject]@{
+        Name            = 'FakeStorePkg'
+        PackageFullName = 'FakeStorePkg_1.0.0.0_x64__fakepublisher'
+        InstallLocation = '$escPkgDir'
+    })
+}
+"@
     }
 
     $scriptContent = @"
@@ -84,8 +111,10 @@ Set-StrictMode -Version Latest
 . '$escFunc'
 # Override Find-UninstallEntry with a fake implementation
 function Find-UninstallEntry { param([string]`$Pattern); $fakeBody }
-`$env:PATH    = '$escPath'
-`$env:PATHEXT = '.COM;.EXE;.BAT;.CMD'
+$storeOverride
+`$env:PATH         = '$escPath'
+`$env:PATHEXT      = '.COM;.EXE;.BAT;.CMD'
+`$env:LOCALAPPDATA = '$escLocalAppData'
 `$captured = @(Invoke-ExeConflictCheck -toolsetdir '$escToolset' ``
     -ExeName '$escExe' -DisplayName '$escDisplay' ``
     -UninstallSearch '$escSearch' -NoInteraction `$true 3>&1)
@@ -103,25 +132,32 @@ foreach (`$item in `$captured) {
     } finally {
         Remove-Item $funcFile   -Force -ErrorAction SilentlyContinue
         Remove-Item $mainScript -Force -ErrorAction SilentlyContinue
+        if ($fakeStorePkgDir) { Remove-Item $fakeStorePkgDir -Recurse -Force -ErrorAction SilentlyContinue }
     }
 }
 
 # -- Setup temp dirs ----------------------------------------------------------
-$tmp         = [System.IO.Path]::GetTempPath()
-$uid         = [guid]::NewGuid().ToString('N').Substring(0, 8)
-$fakeToolset = Join-Path $tmp "ec-toolset-$uid"
-$fakeAdmin   = Join-Path $tmp "ec-admin-$uid"
-$fakeShims   = Join-Path $fakeToolset "shims"
+$tmp              = [System.IO.Path]::GetTempPath()
+$uid              = [guid]::NewGuid().ToString('N').Substring(0, 8)
+$fakeToolset      = Join-Path $tmp "ec-toolset-$uid"
+$fakeAdmin        = Join-Path $tmp "ec-admin-$uid"
+$fakeShims        = Join-Path $fakeToolset "shims"
+$fakeLocalAppData = Join-Path $tmp "ec-localappdata-$uid"
+$fakeWindowsApps  = Join-Path $fakeLocalAppData "Microsoft\WindowsApps"
 
 try {
-    New-Item -Force -ItemType Directory $fakeShims | Out-Null
-    New-Item -Force -ItemType Directory $fakeAdmin | Out-Null
-    Set-Content (Join-Path $fakeShims "node.cmd")   "@echo off" -Encoding ASCII
-    Set-Content (Join-Path $fakeShims "python.cmd") "@echo off" -Encoding ASCII
-    Set-Content (Join-Path $fakeShims "code.cmd")   "@echo off" -Encoding ASCII
-    Set-Content (Join-Path $fakeAdmin "node.cmd")   "@echo off" -Encoding ASCII
-    Set-Content (Join-Path $fakeAdmin "python.cmd") "@echo off" -Encoding ASCII
-    Set-Content (Join-Path $fakeAdmin "code.cmd")   "@echo off" -Encoding ASCII
+    New-Item -Force -ItemType Directory $fakeShims       | Out-Null
+    New-Item -Force -ItemType Directory $fakeAdmin       | Out-Null
+    New-Item -Force -ItemType Directory $fakeWindowsApps | Out-Null
+    Set-Content (Join-Path $fakeShims "node.cmd")         "@echo off" -Encoding ASCII
+    Set-Content (Join-Path $fakeShims "python.cmd")       "@echo off" -Encoding ASCII
+    Set-Content (Join-Path $fakeShims "code.cmd")         "@echo off" -Encoding ASCII
+    Set-Content (Join-Path $fakeAdmin "node.cmd")         "@echo off" -Encoding ASCII
+    Set-Content (Join-Path $fakeAdmin "python.cmd")       "@echo off" -Encoding ASCII
+    Set-Content (Join-Path $fakeAdmin "code.cmd")         "@echo off" -Encoding ASCII
+    # Simulate Microsoft Store app execution aliases: cmd stubs in WindowsApps
+    Set-Content (Join-Path $fakeWindowsApps "python.cmd") "@echo off" -Encoding ASCII
+    Set-Content (Join-Path $fakeWindowsApps "wsl.cmd")    "@echo off" -Encoding ASCII
 
     # [EC-1] Conflict: node in admin dir alongside toolset node
     Write-Host "[EC-1] Conflict detection: node"
@@ -172,9 +208,42 @@ try {
     Assert "EC-7: shows manual removal message" ($out7 -match "Control Panel|manually")
     Assert "EC-7: no winget when no search"     (-not ($out7 -match "winget"))
 
+    # [EC-8] Microsoft Store app execution alias in WindowsApps: silently skipped, no warning
+    Write-Host "[EC-8] WindowsApps Microsoft Store alias is silently skipped"
+    $out8 = Invoke-ConflictCheckTest -ToolsetDir $fakeToolset `
+        -TestPath "$fakeShims;$fakeWindowsApps" -ExeName "python" -DisplayName "Python" `
+        -LocalAppData $fakeLocalAppData
+    Assert "EC-8: no warning for WindowsApps alias" (-not ($out8 -match "WARNING_DETECTED"))
+
+    # [EC-9] Real conflict + WindowsApps alias present: only the real install is warned
+    Write-Host "[EC-9] Real conflict alongside WindowsApps alias: only real one flagged"
+    $out9 = Invoke-ConflictCheckTest -ToolsetDir $fakeToolset `
+        -TestPath "$fakeShims;$fakeAdmin;$fakeWindowsApps" -ExeName "python" -DisplayName "Python" `
+        -LocalAppData $fakeLocalAppData
+    Assert "EC-9: warning emitted for real conflict"    ($out9 -match "WARNING_DETECTED")
+    Assert "EC-9: warning references admin path"        ($out9 -match [regex]::Escape($fakeAdmin))
+    Assert "EC-9: WindowsApps alias path not flagged"   (-not ($out9 -match [regex]::Escape($fakeWindowsApps)))
+
+    # [EC-10] WindowsApps path check is case-insensitive (OrdinalIgnoreCase)
+    Write-Host "[EC-10] WindowsApps path check is case-insensitive"
+    $out10 = Invoke-ConflictCheckTest -ToolsetDir $fakeToolset `
+        -TestPath "$fakeShims;$fakeWindowsApps" -ExeName "python" -DisplayName "Python" `
+        -LocalAppData $fakeLocalAppData.ToUpper()
+    Assert "EC-10: no warning when LOCALAPPDATA casing differs" (-not ($out10 -match "WARNING_DETECTED"))
+
+    # [EC-11] Store-installed python in WindowsApps: warned, Remove-AppxPackage offered, no elevation
+    Write-Host "[EC-11] Store-installed python in WindowsApps: warned with Remove-AppxPackage"
+    $out11 = Invoke-ConflictCheckTest -ToolsetDir $fakeToolset `
+        -TestPath "$fakeShims;$fakeWindowsApps" -ExeName "python" -DisplayName "Python" `
+        -LocalAppData $fakeLocalAppData -FakeStoreExeName "python.cmd"
+    Assert "EC-11: warning emitted for Store python"       ($out11 -match "WARNING_DETECTED")
+    Assert "EC-11: Remove-AppxPackage mentioned"           ($out11 -match "Remove-AppxPackage")
+    Assert "EC-11: no elevation required for Store uninstall" ($out11 -match "no elevation required")
+
 } finally {
-    if (Test-Path $fakeToolset) { Remove-Item $fakeToolset -Recurse -Force -ErrorAction SilentlyContinue }
-    if (Test-Path $fakeAdmin)   { Remove-Item $fakeAdmin   -Recurse -Force -ErrorAction SilentlyContinue }
+    if (Test-Path $fakeToolset)      { Remove-Item $fakeToolset      -Recurse -Force -ErrorAction SilentlyContinue }
+    if (Test-Path $fakeAdmin)        { Remove-Item $fakeAdmin        -Recurse -Force -ErrorAction SilentlyContinue }
+    if (Test-Path $fakeLocalAppData) { Remove-Item $fakeLocalAppData -Recurse -Force -ErrorAction SilentlyContinue }
 }
 
 Write-Host ""

--- a/toolset.ps1
+++ b/toolset.ps1
@@ -63,19 +63,28 @@ function Invoke-ExeConflictCheck {
         [bool]$NoInteraction
     )
     try {
-        # Lazy cache: Get-AppxPackage is slow; populate once and reuse across all calls
+        # Lazy cache: Get-AppxPackage is slow; populate once and reuse across all calls.
+        # Guard with Get-Command first: the cmdlet may be absent on server SKUs or containers,
+        # in which case a missing cmdlet throws a terminating CommandNotFoundException that
+        # -ErrorAction SilentlyContinue cannot suppress.
         if (-not (Get-Variable -Name 'CachedAppxPackages' -Scope Script -ErrorAction SilentlyContinue)) {
-            $script:CachedAppxPackages = @(Get-AppxPackage -ErrorAction SilentlyContinue)
+            $script:CachedAppxPackages = if (Get-Command 'Get-AppxPackage' -ErrorAction SilentlyContinue) {
+                @(Get-AppxPackage -ErrorAction SilentlyContinue)
+            } else { @() }
         }
 
         $allExes = @(Get-Command $ExeName -All -CommandType Application -ErrorAction SilentlyContinue)
         if ($allExes.Count -eq 0) { return }
 
-        $windowsAppsPath = Join-Path $env:LOCALAPPDATA 'Microsoft\WindowsApps'
+        # Normalize toolset prefix with trailing separator to avoid matching sibling dirs
+        # (e.g. C:\toolset must not match C:\toolset-old).
+        $toolsetPrefix   = $toolsetdir.TrimEnd('\', '/') + '\'
+        # Guard LOCALAPPDATA: unset in some service/container contexts
+        $windowsAppsPath = if ($env:LOCALAPPDATA) { (Join-Path $env:LOCALAPPDATA 'Microsoft\WindowsApps').TrimEnd('\') + '\' } else { $null }
 
         foreach ($cmd in $allExes) {
             $exePath = $cmd.Source
-            if ($exePath.StartsWith($toolsetdir, [System.StringComparison]::OrdinalIgnoreCase)) { continue }
+            if ($exePath.StartsWith($toolsetPrefix, [System.StringComparison]::OrdinalIgnoreCase)) { continue }
 
             # Microsoft Store app execution aliases live in %LOCALAPPDATA%\Microsoft\WindowsApps.
             # Windows 11 pre-places dead 0-byte stubs there (e.g. python.exe, wsl.exe) that
@@ -83,7 +92,7 @@ function Invoke-ExeConflictCheck {
             # But if a real Store package IS installed we detect it via the cached package list
             # and offer a no-elevation Remove-AppxPackage uninstall instead of winget/registry.
             $storePackage = $null
-            if ($exePath.StartsWith($windowsAppsPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+            if ($windowsAppsPath -and $exePath.StartsWith($windowsAppsPath, [System.StringComparison]::OrdinalIgnoreCase)) {
                 $exeFilename  = [System.IO.Path]::GetFileName($exePath)
                 $storePackage = $script:CachedAppxPackages | Where-Object {
                     $_.InstallLocation -and

--- a/toolset.ps1
+++ b/toolset.ps1
@@ -70,7 +70,9 @@ function Invoke-ExeConflictCheck {
             $exePath = $cmd.Source
             if ($exePath.StartsWith($toolsetdir)) { continue }
             # Ignore fake executables that serve as shortcuts for installing programs on Windows 11 (python.exe, wsl.exe, etc..)
-            if ($cmd.Length == 0) { continue }
+            $file = Get-Item $cmd.Path
+            
+            if ($file.Length -eq 0) { continue }
             $warnLine = "  WARNING: $DisplayName detected outside toolset!"
             $confLine = "  This will conflict with the toolset version."
             $innerW   = [Math]::Max($warnLine.Length, $confLine.Length) + 2

--- a/toolset.ps1
+++ b/toolset.ps1
@@ -63,16 +63,35 @@ function Invoke-ExeConflictCheck {
         [bool]$NoInteraction
     )
     try {
-        $allExes = @(Get-Command $ExeName -All -ErrorAction SilentlyContinue)
+        # Lazy cache: Get-AppxPackage is slow; populate once and reuse across all calls
+        if (-not (Get-Variable -Name 'CachedAppxPackages' -Scope Script -ErrorAction SilentlyContinue)) {
+            $script:CachedAppxPackages = @(Get-AppxPackage -ErrorAction SilentlyContinue)
+        }
+
+        $allExes = @(Get-Command $ExeName -All -CommandType Application -ErrorAction SilentlyContinue)
         if ($allExes.Count -eq 0) { return }
-        
+
+        $windowsAppsPath = Join-Path $env:LOCALAPPDATA 'Microsoft\WindowsApps'
+
         foreach ($cmd in $allExes) {
             $exePath = $cmd.Source
             if ($exePath.StartsWith($toolsetdir)) { continue }
-            # Ignore fake executables that serve as shortcuts for installing programs on Windows 11 (python.exe, wsl.exe, etc..)
-            $file = Get-Item $cmd.Path
-            
-            if ($file.Length -eq 0) { continue }
+
+            # Microsoft Store app execution aliases live in %LOCALAPPDATA%\Microsoft\WindowsApps.
+            # Windows 11 pre-places dead 0-byte stubs there (e.g. python.exe, wsl.exe) that
+            # open the Store when run -- those must be silently skipped.
+            # But if a real Store package IS installed we detect it via the cached package list
+            # and offer a no-elevation Remove-AppxPackage uninstall instead of winget/registry.
+            $storePackage = $null
+            if ($exePath.StartsWith($windowsAppsPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $exeFilename  = [System.IO.Path]::GetFileName($exePath)
+                $storePackage = $script:CachedAppxPackages | Where-Object {
+                    $_.InstallLocation -and
+                    (Test-Path (Join-Path $_.InstallLocation $exeFilename) -ErrorAction SilentlyContinue)
+                } | Select-Object -First 1
+                if (-not $storePackage) { continue }  # dead stub - skip silently
+            }
+
             $warnLine = "  WARNING: $DisplayName detected outside toolset!"
             $confLine = "  This will conflict with the toolset version."
             $innerW   = [Math]::Max($warnLine.Length, $confLine.Length) + 2
@@ -84,10 +103,14 @@ function Invoke-ExeConflictCheck {
             Write-Host $border -ForegroundColor Red
             Write-Host "  Detected: $exePath" -ForegroundColor Yellow
 
-            # Determine uninstall command: registry first, winget fallback, else manual
-            $uninstallCmd = $null
+            # Determine uninstall method: Store package > registry entry > winget fallback
+            $uninstallCmd    = $null
             $uninstallSource = $null
-            if (-not [string]::IsNullOrEmpty($UninstallSearch)) {
+            $isStorePackage  = $null -ne $storePackage
+
+            if ($isStorePackage) {
+                $uninstallSource = "Microsoft Store ($($storePackage.Name))"
+            } elseif (-not [string]::IsNullOrEmpty($UninstallSearch)) {
                 $entry = Find-UninstallEntry -Pattern $UninstallSearch
                 if ($entry) {
                     $quietStr = if ($entry.PSObject.Properties['QuietUninstallString']) { $entry.QuietUninstallString } else { $null }
@@ -95,37 +118,52 @@ function Invoke-ExeConflictCheck {
                     $uninstallCmd = if ($quietStr) { $quietStr } elseif ($uninstStr) { $uninstStr } else { $null }
                     $uninstallSource = "Add/Remove Programs: $($entry.DisplayName)"
                 }
-            }
-            if (-not $uninstallCmd -and -not [string]::IsNullOrEmpty($UninstallSearch)) {
-                # Winget fallback: strip trailing wildcard from search pattern
-                $wingetName = $UninstallSearch.TrimEnd('*').Trim()
-                $uninstallCmd = "winget uninstall --name `"$wingetName`""
-                $uninstallSource = "winget (fallback)"
+                if (-not $uninstallCmd) {
+                    # Winget fallback: strip trailing wildcard from search pattern
+                    $wingetName      = $UninstallSearch.TrimEnd('*').Trim()
+                    $uninstallCmd    = "winget uninstall --name `"$wingetName`""
+                    $uninstallSource = "winget (fallback)"
+                }
             }
 
-            if ($uninstallCmd) {
+            if ($isStorePackage -or $uninstallCmd) {
                 Write-Host "  Uninstall via $uninstallSource" -ForegroundColor Cyan
-                Write-Host "  Command: $uninstallCmd" -ForegroundColor Cyan
+                if ($isStorePackage) {
+                    Write-Host "  Command: Remove-AppxPackage (no elevation required)" -ForegroundColor Cyan
+                } else {
+                    Write-Host "  Command: $uninstallCmd" -ForegroundColor Cyan
+                }
                 if (-not $NoInteraction) {
-                    $answer = Read-Host "Uninstall now? (requires elevation) [Y/N]"
+                    $elevNote = if ($isStorePackage) { "(no elevation required)" } else { "(requires elevation)" }
+                    $answer = Read-Host "Uninstall now? $elevNote [Y/N]"
                     if ($answer -match '^[Yy]$') {
                         try {
-                            $proc = Start-Process cmd -Verb RunAs -Wait -PassThru `
-                                -ArgumentList "/c", $uninstallCmd
-                            if ($proc.ExitCode -eq 0) {
+                            if ($isStorePackage) {
+                                Remove-AppxPackage -Package $storePackage.PackageFullName -ErrorAction Stop
                                 Write-Host "$DisplayName uninstalled. Please re-run toolset.ps1." -ForegroundColor Green
                                 exit 0
                             } else {
-                                Write-Warning "Uninstall returned exit code $($proc.ExitCode). Please uninstall manually via Control Panel, then re-run toolset.ps1."
+                                $proc = Start-Process cmd -Verb RunAs -Wait -PassThru `
+                                    -ArgumentList "/c", $uninstallCmd
+                                if ($proc.ExitCode -eq 0) {
+                                    Write-Host "$DisplayName uninstalled. Please re-run toolset.ps1." -ForegroundColor Green
+                                    exit 0
+                                } else {
+                                    Write-Warning "Uninstall returned exit code $($proc.ExitCode). Please uninstall manually via Control Panel, then re-run toolset.ps1."
+                                }
                             }
                         } catch {
-                            Write-Warning "Uninstall failed: $_. Please uninstall manually via Control Panel, then re-run toolset.ps1."
+                            Write-Warning "Uninstall failed: $_. Please uninstall manually, then re-run toolset.ps1."
                         }
                     } else {
                         Write-Warning "Please uninstall $DisplayName manually, then re-run toolset.ps1."
                     }
                 } else {
-                    Write-Warning "Admin-installed $DisplayName at $exePath. Uninstall it manually, then re-run toolset.ps1."
+                    if ($isStorePackage) {
+                        Write-Warning "Store-installed $DisplayName at $exePath. Run: Remove-AppxPackage -Package '$($storePackage.PackageFullName)', then re-run toolset.ps1."
+                    } else {
+                        Write-Warning "Admin-installed $DisplayName at $exePath. Uninstall it manually, then re-run toolset.ps1."
+                    }
                 }
             } else {
                 Write-Host "  No automated uninstall found. Remove $DisplayName via Control Panel manually." -ForegroundColor Yellow

--- a/toolset.ps1
+++ b/toolset.ps1
@@ -65,11 +65,12 @@ function Invoke-ExeConflictCheck {
     try {
         $allExes = @(Get-Command $ExeName -All -ErrorAction SilentlyContinue)
         if ($allExes.Count -eq 0) { return }
-
+        
         foreach ($cmd in $allExes) {
             $exePath = $cmd.Source
             if ($exePath.StartsWith($toolsetdir)) { continue }
-
+            # Ignore fake executables that serve as shortcuts for installing programs on Windows 11 (python.exe, wsl.exe, etc..)
+            if ($cmd.Length == 0) { continue }
             $warnLine = "  WARNING: $DisplayName detected outside toolset!"
             $confLine = "  This will conflict with the toolset version."
             $innerW   = [Math]::Max($warnLine.Length, $confLine.Length) + 2

--- a/toolset.ps1
+++ b/toolset.ps1
@@ -75,7 +75,7 @@ function Invoke-ExeConflictCheck {
 
         foreach ($cmd in $allExes) {
             $exePath = $cmd.Source
-            if ($exePath.StartsWith($toolsetdir)) { continue }
+            if ($exePath.StartsWith($toolsetdir, [System.StringComparison]::OrdinalIgnoreCase)) { continue }
 
             # Microsoft Store app execution aliases live in %LOCALAPPDATA%\Microsoft\WindowsApps.
             # Windows 11 pre-places dead 0-byte stubs there (e.g. python.exe, wsl.exe) that


### PR DESCRIPTION
toolset.ps1 : Verification step for Ignore fake executables that serve as shortcuts for installing programs on Windows 11 (python.exe, wsl.exe, etc..)